### PR TITLE
Replace log with logrus

### DIFF
--- a/internal/clients/correlation_id.go
+++ b/internal/clients/correlation_id.go
@@ -1,7 +1,7 @@
 package clients
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/Azure/go-autorest/autorest"

--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_cluster_root_token.go
+++ b/internal/provider/resource_cluster_root_token.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_snapshot.go
+++ b/internal/provider/resource_snapshot.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"time"
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/hashicorp/terraform-provider-hcs/internal/provider"


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-hcs', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
examples
templates
.release
scripts
.github
docs
internal
.git
version
.vscode
provider
marketplace_plan
federation
data-sources
cluster_root_token
quick_start
resources
cluster_vnet_peering
hcs_agent_helm_config
hcs_cluster
hcs_federation_token
hcs_plan_defaults
hcs_agent_kubernetes_secret
hcs_consul_versions
hcs_cluster_root_token
hcs_cluster
hcs_snapshot
guides
workflows
data-sources
resources
guides
provider
clients
consul
helper
hcsmeta
hcs-ama-api-spec
models
swagger
objects
info
branches
logs
refs
hooks
97
1b
08
65
20
99
9f
4e
b6
e2
78
e6
66
fe
01
89
5a
c5
1e
dc
b7
ee
11
c8
1f
53
7a
7c
07
59
87
81
9e
75
52
8e
96
e3
29
ac
e7
a3
db
ea
ff
bf
76
3e
34
4c
26
06
85
19
fd
9b
a0
f3
b8
b4
c1
a6
0f
74
93
5b
51
cf
e9
pack
f7
9a
e8
da
d7
ce
3a
b5
ae
be
a2
info
80
e5
ed
3c
9d
15
a5
56
7d
2b
ad
09
2e
d4
73
6d
27
3b
88
0c
d5
a8
16
40
aa
ab
3d
b9
23
00
37
83
4f
d3
8f
39
36
55
17
68
f9
c3
04
2c
8a
48
32
cd
91
6a
14
2d
cc
f4
03
a1
6f
86
62
df
0a
30
d8
refs
heads
tags
heads

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)